### PR TITLE
Changed default for j-console-cmd to "ijconsole"

### DIFF
--- a/j-console.el
+++ b/j-console.el
@@ -46,7 +46,7 @@
   :group 'j
   :prefix "j-console-")
 
-(defcustom j-console-cmd "jconsole"
+(defcustom j-console-cmd "ijconsole"
   "Name of the executable used for the J REPL session"
   :type 'string
   :group 'j-console)


### PR DESCRIPTION
Since "jconsole" is also the name of the "Java Monitoring and Management Console", J provides another name for the J REPL: ijconsole. I changed the default for `j-console-cmd` from `"jconsole"` to `"ijconsole"`. Now, the J REPL appears when I execute the `j-console` command.
