### PR TITLE
Typo

### DIFF
--- a/j-console.el
+++ b/j-console.el
@@ -6,7 +6,7 @@
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/zellio/j-mode
 ;; Version: 1.1.1
-;; Keywords: J, Langauges
+;; Keywords: J, Languages
 
 ;; This file is not part of GNU Emacs.
 

--- a/j-font-lock.el
+++ b/j-font-lock.el
@@ -6,7 +6,7 @@
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/zellio/j-mode
 ;; Version: 1.1.1
-;; Keywords: J, Langauges
+;; Keywords: J, Languages
 
 ;; This file is not part of GNU Emacs.
 

--- a/j-mode.el
+++ b/j-mode.el
@@ -6,7 +6,7 @@
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/zellio/j-mode
 ;; Version: 1.1.1
-;; Keywords: J, Langauges
+;; Keywords: J, Languages
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This fixes a typo so that the package gets correctly listed when filtering Emacs packages buffer with the "languages" keyword.