### PR TITLE
Remove if-let macro to avoid conflict with emacs's if-let.

### DIFF
--- a/j-help.el
+++ b/j-help.el
@@ -41,19 +41,6 @@
 
 ;;; Code:
 
-(defmacro if-let ( binding then &optional else )
-  "Bind value according to BINDING and check for truthy-ness
-If the test passes then eval THEN with the BINDING varlist bound
-If no, eval ELSE with no binding"
-  (let* ((sym (caar binding))
-         (tst (cdar binding))
-         (gts (gensym)))
-    `(let ((,gts ,@tst))
-       (if ,gts
-         (let ((,sym ,gts))
-           ,then)
-         ,else))))
-
 (defun group-by* ( list fn prev coll agr )
   "Helper method for the group-by function. Should not be called directly."
   (if list


### PR DESCRIPTION
if-let is not used in j-mode and defined in emacs's default.
https://github.com/emacs-mirror/emacs/blob/c10024911d6c225645c22e87a7326c13c0116ac6/lisp/emacs-lisp/subr-x.el#L158
