### PR TITLE
Version 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ place in your load path and load / require normally.
 (autoload 'j-mode "j-mode.el" "Major mode for editing J files" t)
 
 ;; Add for detection of j source files if the auto-load fails
-(add-to-list 'auto-mode-alist '("\\.ij[rstp]$" . j-mode))
+(add-to-list 'auto-mode-alist '("\\.ij[rsp]$" . j-mode))
+(add-to-list 'auto-mode-alist '("\\.ijt$" . j-lab-mode))
 ```
 
 ## J Font Lock
@@ -28,7 +29,7 @@ various parts of speech. Those faces are `j-verb-face` `j-adverb-face`
 standard built in faces to help meet your need.
 
 ```lisp
-(custom-set-face
+(custom-set-faces
  '(j-verb-face ((t (:foreground "Red"))))
  '(j-adverb-face ((t (:foreground "Green"))))
  '(j-conjunction-face ((t (:foreground "Blue"))))

--- a/j-console.el
+++ b/j-console.el
@@ -2,10 +2,10 @@
 ;;; j-mode.el --- Major mode for editing J programs
 
 ;; Copyright (C) 2012 Zachary Elliott
-;; Copyright (C) 2023 LdBeth
+;; Copyright (C) 2023, 2024 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/ldbeth/j-mode
+;; URL: http://github.com/zellio/j-mode
 ;; Version: 2.0.1
 ;; Keywords: J, Langauges
 

--- a/j-console.el
+++ b/j-console.el
@@ -6,7 +6,7 @@
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/ldbeth/j-mode
-;; Version: 2.0.0
+;; Version: 2.0.1
 ;; Keywords: J, Langauges
 
 ;; This file is not part of GNU Emacs.

--- a/j-console.el
+++ b/j-console.el
@@ -128,7 +128,7 @@ the containing buffer"
         (session (j-console-ensure-session)))
     (pop-to-buffer (process-buffer session))
     (goto-char (point-max))
-    (insert (format "\n%s\n" region))
+    (insert (format "%s" region))
     (comint-send-input)))
 
 (defun j-console-execute-line ()
@@ -140,6 +140,17 @@ the containing buffer"
   "Sends current buffer to the j-console-cmd session and exectues it"
   (interactive)
   (j-console-execute-region (point-min) (point-max)))
+
+;;XXX should maybe check that we are indeed in an explicit def, unlike
+;;elisp counterpart
+(defun j-console-execute-definition ()
+  "Send the current explicit definition to a running J session."
+  (interactive)
+  (save-excursion
+    (mark-defun)
+    (let ((start (point))
+          (end (mark)))
+      (j-console-execute-region start end))))
 
 (provide 'j-console)
 

--- a/j-console.el
+++ b/j-console.el
@@ -37,10 +37,6 @@
 
 (require 'comint)
 
-
-;; (defconst j-console-version "1.1.1"
-;;   "`j-console' version")
-
 (defgroup j-console nil
   "REPL integration extention for `j-mode'"
   :group 'applications

--- a/j-console.el
+++ b/j-console.el
@@ -1,12 +1,13 @@
-
+;; -*- lexical-binding:t -*-
 ;;; j-mode.el --- Major mode for editing J programs
 
 ;; Copyright (C) 2012 Zachary Elliott
+;; Copyright (C) 2023 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/zellio/j-mode
-;; Version: 1.1.1
-;; Keywords: J, Languages
+;; URL: http://github.com/ldbeth/j-mode
+;; Version: 2.0.0
+;; Keywords: J, Langauges
 
 ;; This file is not part of GNU Emacs.
 
@@ -46,7 +47,7 @@
   :group 'j
   :prefix "j-console-")
 
-(defcustom j-console-cmd "ijconsole"
+(defcustom j-console-cmd "jc"
   "Name of the executable used for the J REPL session"
   :type 'string
   :group 'j-console)
@@ -86,7 +87,8 @@ Should be NIL if there is no file not the empty string"
 
 (defun j-console-create-session ()
   "Starts a comint session wrapped around the j-console-cmd"
-  (setq comint-process-echoes t)
+  (setq comint-process-echoes nil
+        comint-use-prompt-regexp t)
   (apply 'make-comint j-console-cmd-buffer-name
          j-console-cmd j-console-cmd-init-file j-console-cmd-args)
   (mapc
@@ -110,7 +112,8 @@ Should be NIL if there is no file not the empty string"
         (get-process j-console-cmd-buffer-name))))
 
 (define-derived-mode inferior-j-mode comint-mode "Inferior J"
-  "Major mode for J inferior process.")
+  "Major mode for J inferior process."
+  (setq comint-prompt-regexp "\s+"))
 
 ;;;###autoload
 (defun j-console ()
@@ -135,7 +138,7 @@ the containing buffer"
 (defun j-console-execute-line ()
   "Sends current line to the j-console-cmd session and exectues it"
   (interactive)
-  (j-console-execute-region (point-at-bol) (point-at-eol)))
+  (j-console-execute-region (pos-bol) (pos-eol)))
 
 (defun j-console-execute-buffer ()
   "Sends current buffer to the j-console-cmd session and exectues it"

--- a/j-font-lock.el
+++ b/j-font-lock.el
@@ -5,7 +5,7 @@
 ;; Copyright (C) 2023, 2024 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/ldbeth/j-mode
+;; URL: http://github.com/zellio/j-mode
 ;; Version: 2.0.1
 ;; Keywords: J, Langauges
 

--- a/j-font-lock.el
+++ b/j-font-lock.el
@@ -83,13 +83,13 @@
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\{ "."   table)
     (modify-syntax-entry ?\} "."   table)
-    (modify-syntax-entry ?\[ "."   table)
-    (modify-syntax-entry ?\] "."   table)
-    (modify-syntax-entry ?\" "."   table)
+    (modify-syntax-entry '(?! . ?&)  "." table)
+    (modify-syntax-entry '(?* . ?/)  "." table)
+    (modify-syntax-entry '(?: . ?@)  "." table)
+    (modify-syntax-entry '(?\[ . ?^) "." table)
     (modify-syntax-entry ?\\ "."   table)
-    (modify-syntax-entry ?\. "w"   table)
-    (modify-syntax-entry ?\: "w"   table)
-    (modify-syntax-entry ?\_ "w"   table)
+    ;; (modify-syntax-entry ?\. "_"   table)
+    ;; (modify-syntax-entry ?\: "_"   table)
     (modify-syntax-entry ?\( "()"  table)
     (modify-syntax-entry ?\) ")("  table)
     (modify-syntax-entry ?\' "\""  table)
@@ -99,6 +99,11 @@
     (modify-syntax-entry ?\r ">"   table)
     table)
   "Syntax table for j-mode")
+
+(defalias 'j-mode-syntax-propertize
+  (syntax-propertize-rules
+   ("^\\()\\)" (1 "."))
+   ("{{\\()\\)\s" (1 "."))))
 
 (defvar j-font-lock-constants
   '(
@@ -171,11 +176,11 @@
   (append j-font-lock-len-3-others j-font-lock-len-2-others j-font-lock-len-1-others))
 
 (defvar j-font-lock-len-3-conjunctions
-  '("&.:" "F.." "F.:" "F:." "F::"))
+  '("&.:" "F.." "F.:" "F:." "F::" " ::" " :."))
 (defvar j-font-lock-len-2-conjunctions
   '("t." "S:" "L:" "H." "D:" "D." "d." "F." "F:" "m."
     "&:" "&." "@:" "@." "`:" "!:" "!." ";."
-    "::" ":." ".:" ".." "^:" " ." " :"))
+    "^:" " ." " :"))
 (defvar j-font-lock-len-1-conjunctions
   '("&" "@" "`" "\""))
 (defvar j-font-lock-conjunctions
@@ -186,25 +191,34 @@
 
 (defvar j-font-lock-keywords
   `(
-    (,(rx (seq (group (regexp "[_a-zA-Z0-9]+"))
+    (,(rx (seq (group (* (any "_a-zA-Z0-9")))
                (* "\s")
                (group "=" (or "." ":"))))
      (1 font-lock-variable-name-face) (2 j-other-face))
+    (,(rx bow (any "a-zA-Z")
+          (* (any "_a-zA-Z0-9"))
+          "_:") ;; Self-Effacing References
+     . font-lock-warning-face)
     (,(regexp-opt j-font-lock-foreign-conjunctions) . font-lock-warning-face)
-    (,(rx bow (or (regexp (regexp-opt j-font-lock-control-structures))
-                  (seq (or "for" "goto" "label")
-                       (regexp "_[a-zA-Z]+\\."))))
+    (,(rx symbol-start
+          (or (regexp (regexp-opt j-font-lock-control-structures))
+              (seq (or "for" "goto" "label")
+                   "_" (+ (any "a-zA-Z")) ".")))
      . font-lock-keyword-face)
-    (,(rx bow (regexp (regexp-opt j-font-lock-builtins)) eow)
+    (,(rx symbol-start (regexp (regexp-opt j-font-lock-builtins)) eow)
      . font-lock-builtin-face)
-    (,(regexp-opt j-font-lock-constants) . font-lock-constant-face)
+    (,(rx symbol-start
+          (regexp
+           (regexp-opt j-font-lock-constants))
+          eow)
+     . font-lock-constant-face)
     (,(regexp-opt j-font-lock-len-3-verbs)
      . j-verb-face)
     (,(regexp-opt j-font-lock-len-3-adverbs) . j-adverb-face)
     (,(regexp-opt j-font-lock-len-3-conjunctions) . j-conjunction-face)
     ;;(,(regexp-opt j-font-lock-len-3-others) . )
     (,(rx (or (regexp (regexp-opt j-font-lock-len-2-verbs))
-              (seq bow (opt "_") (regexp "[0-9_]") ":")))
+              (seq symbol-start (opt "_") (regexp "[0-9_]") ":")))
      . j-verb-face)
     (,(regexp-opt j-font-lock-len-2-adverbs) . j-adverb-face)
     (,(regexp-opt j-font-lock-len-2-conjunctions) . j-conjunction-face)

--- a/j-font-lock.el
+++ b/j-font-lock.el
@@ -42,7 +42,7 @@
 ;; USA.
 
 ;;; Code:
-
+(eval-when-compile (require 'rx))
 
 (defgroup j-font-lock nil
   "font-lock extension for j-mode"
@@ -89,6 +89,7 @@
     (modify-syntax-entry ?\\ "."   table)
     (modify-syntax-entry ?\. "w"   table)
     (modify-syntax-entry ?\: "w"   table)
+    (modify-syntax-entry ?\_ "w"   table)
     (modify-syntax-entry ?\( "()"  table)
     (modify-syntax-entry ?\) ")("  table)
     (modify-syntax-entry ?\' "\""  table)
@@ -102,7 +103,7 @@
 (defvar j-font-lock-constants
   '(
     ;; char codes
-    "CR" "CRLF" "LF" "TAB"
+    "CR" "CRLF" "LF" "TAB" "EMPTY"
     ;; grammar codes
     ;;0     1          2            3      3       4
     "noun" "adverb"  "conjunction" "verb" "monad" "dyad"
@@ -118,6 +119,8 @@
     "conl" "copath" "coreset"
     ;; environment
     "type" "names" "nameclass" "nc" "namelist" "nl" "erase"
+    ;; dll
+    "cd" "memr" "memw" "mema" "memf" "memu" "cdf"
     ;; system
     "assert"
     "getenv" "setenv" "exit" "stdin" "stdout" "stderr"
@@ -127,9 +130,7 @@
 (defvar j-font-lock-control-structures
   '("assert."  "break."  "continue."  "while."  "whilst."  "for."  "do."  "end."
     "if."  "else."  "elseif."  "return."  "select."  "case."  "fcase."  "throw."
-    "try."  "catch."  "catchd."  "catcht."  "end."
-    ;; "for_[a-zA-Z]+\\."  "goto_[a-zA-Z]+\\."  "label_[a-zA-Z]+\\."
-    ))
+    "try."  "catch."  "catchd."  "catcht."  "end."))
 
 (defvar j-font-lock-direct-definition
   '("{{" "}}"))
@@ -139,12 +140,12 @@
     "15!:" "18!:" "128!:" ))
 
 (defvar j-font-lock-len-3-verbs
-  '("p.." "{::" "__:"))
+  '("p.." "{::"))
 (defvar j-font-lock-len-2-verbs
   '("x:" "u:" "s:" "r." "q:" "p:" "p." "o." "L." "j." "I." "i:" "i." "E." "e."
-    "C." "A." "?." "\":" "\"." "}:" "}." "{:" "{." "[:" "/:" "\\:" "#:" "#." ";:" ",:"
+    "C." "A." "T." "?." "\":" "\"." "}:" "}." "{:" "{." "[:" "/:" "\\:" "#:" "#." ";:" ",:"
     ",." "|:" "|." "~:" "~." "$:" "$." "^." "%:" "%." "-:" "-." "*:" "*."  "+:"
-    "+." "_:" ">:" ">." "<:" "<."))
+    "+." ">:" ">." "<:" "<."))
 (defvar j-font-lock-len-1-verbs
   '("?" "{" "]" "[" "!" "#" ";" "," "|" "$" "^" "%" "-" "*" "+" ">" "<" "="))
 (defvar j-font-lock-verbs
@@ -172,11 +173,11 @@
 (defvar j-font-lock-len-3-conjunctions
   '("&.:" "F.." "F.:" "F:." "F::"))
 (defvar j-font-lock-len-2-conjunctions
-  '("T." "t." "S:" "L:" "H." "D:" "D." "d." "F." "F:" "m."
+  '("t." "S:" "L:" "H." "D:" "D." "d." "F." "F:" "m."
     "&:" "&." "@:" "@." "`:" "!:" "!." ";."
-    "::" ":." ".:" ".." "^:" " ."))
+    "::" ":." ".:" ".." "^:" " ." " :"))
 (defvar j-font-lock-len-1-conjunctions
-  '("&" "@" "`" "\"" ":"))
+  '("&" "@" "`" "\""))
 (defvar j-font-lock-conjunctions
   (append j-font-lock-len-3-conjunctions
           j-font-lock-len-2-conjunctions
@@ -185,22 +186,25 @@
 
 (defvar j-font-lock-keywords
   `(
-    ("\\([_a-zA-Z0-9]+\\)\s*\\(=[.:]\\)"
+    (,(rx (seq (group (regexp "[_a-zA-Z0-9]+"))
+               (* "\s")
+               (group "=" (or "." ":"))))
      (1 font-lock-variable-name-face) (2 j-other-face))
     (,(regexp-opt j-font-lock-foreign-conjunctions) . font-lock-warning-face)
-    (,(concat "\\<" (regexp-opt j-font-lock-control-structures)
-              "\\|\\(?:\\(for\\|goto\\|label\\)_[a-zA-Z]+\\.\\)")
+    (,(rx bow (or (regexp (regexp-opt j-font-lock-control-structures))
+                  (seq (or "for" "goto" "label")
+                       (regexp "_[a-zA-Z]+\\."))))
      . font-lock-keyword-face)
-    (,(concat "\\<" (regexp-opt j-font-lock-builtins)) . font-lock-builtin-face)
+    (,(rx bow (regexp (regexp-opt j-font-lock-builtins)) eow)
+     . font-lock-builtin-face)
     (,(regexp-opt j-font-lock-constants) . font-lock-constant-face)
-    (,(concat (regexp-opt j-font-lock-len-3-verbs)
-              "\\|\\(?:_[0-9]:\\)")
+    (,(regexp-opt j-font-lock-len-3-verbs)
      . j-verb-face)
     (,(regexp-opt j-font-lock-len-3-adverbs) . j-adverb-face)
     (,(regexp-opt j-font-lock-len-3-conjunctions) . j-conjunction-face)
     ;;(,(regexp-opt j-font-lock-len-3-others) . )
-    (,(concat (regexp-opt j-font-lock-len-2-verbs)
-              "\\|\\(?:[0-9]:\\)")
+    (,(rx (or (regexp (regexp-opt j-font-lock-len-2-verbs))
+              (seq bow (opt "_") (regexp "[0-9_]") ":")))
      . j-verb-face)
     (,(regexp-opt j-font-lock-len-2-adverbs) . j-adverb-face)
     (,(regexp-opt j-font-lock-len-2-conjunctions) . j-conjunction-face)

--- a/j-font-lock.el
+++ b/j-font-lock.el
@@ -102,7 +102,22 @@
     (0 (j-font-lock-nota-bene)))
    ("\\(?:0\\|noun\\)\s+\\(?::\s*0\\|define\\)"
     (0 (j-font-lock-multiline-string ?:)))
-   ("^\\()\\)" (1 (j-font-lock-multiline-string ?\))))
+   ("^\\()\\)$" (1 (j-font-lock-multiline-string ?\))))
+   ("{{)n" (0 (j-font-lock-multiline-string ?\{)))
+   ("}}" (0 (j-font-lock-multiline-string ?\})))
+   ("{{\\()\\)" (1 "."))
+   ("\\('\\)`?[0-9A-Z_a-z ]*\\('\\)\s*=[.:]" (1 ".") (2 "."))
+   ("\\('\\)\\(?:[^'\n]\\|''\\)*\\('\\)" (1 "\"") (2 "\""))))
+
+(defalias 'j-lab-mode-syntax-propertize
+  (syntax-propertize-rules
+   ("\\(N\\)\\(?:B\\.\s*\\(?:===\\|---\\)\\|ote\s*''\\)"
+    (1 (j-font-lock-multiline-string ?N)))
+   ("\\(N\\)\\(B\\)\\..*$" (1 "w 1") (2 "w 2")
+    (0 (j-font-lock-nota-bene)))
+   ("\\(?:0\\|noun\\)\s+\\(?::\s*0\\|define\\)"
+    (0 (j-font-lock-multiline-string ?:)))
+   ("^\\()\\)$" (1 (j-font-lock-multiline-string ?\))))
    ("{{)n" (0 (j-font-lock-multiline-string ?\{)))
    ("}}" (0 (j-font-lock-multiline-string ?\})))
    ("{{\\()\\)" (1 "."))
@@ -118,10 +133,16 @@
     (?: (let* ((ppss (syntax-ppss))
                (string-start (and (eq t (nth 3 ppss)) (nth 8 ppss)))
                (eol (pos-eol)))
-          (unless (or string-start (> (1+ eol) (point-max)))
+          (unless (or (or string-start (> (1+ eol) (point-max)))
+                      (save-excursion
+                        (goto-char (1+ eol))
+                        (looking-at "^)$")))
             (put-text-property eol (1+ eol)
                                'syntax-table (string-to-syntax "|")))
           nil))
+    (?N (let ((ppss (save-excursion (syntax-ppss (match-beginning 1)))))
+          (unless (and (eq t (nth 3 ppss)) (nth 8 ppss)) ; inside string
+            (string-to-syntax "|"))))
     (?\{ (let* ((ppss (save-excursion (backward-char 4) (syntax-ppss)))
                (string-start (and (eq t (nth 3 ppss)) (nth 8 ppss)))
                (quote-starting-pos (- (point) 4)))
@@ -134,8 +155,9 @@
     (?\) (let* ((ppss (save-excursion (backward-char 2) (syntax-ppss)))
                 (string-start (and (eq t (nth 3 ppss)) (nth 8 ppss)))
                 (quote-starting-pos (- (point) 1)))
-           (if (and string-start (eql (char-after string-start)
-                                      ?\n))
+           (if (and string-start (or
+                                  (eql (char-after string-start) ?\n)
+                                  (eql (char-after string-start) ?N)))
                (put-text-property (1- quote-starting-pos) quote-starting-pos
                                   'syntax-table (string-to-syntax "|")))
            (string-to-syntax ".")))
@@ -301,13 +323,16 @@
   "Function for detection of string vs. Comment. Note: J comments
 are three chars longs, there is no easy / evident way to handle
 this in emacs and it poses problems"
-  (let* ((start-pos (nth 8 state)))
+  (let ((start-pos (nth 8 state)))
     (cond
-     ((nth 3 state) (if (and
-                         (eql (char-after start-pos) ?\n)
-                         (j-font-lock-docstring-p state))
-                        font-lock-doc-face
-                      font-lock-string-face))
+     ((nth 3 state)
+      (if (or (and ; A free standing multiline string
+               (eql (char-after start-pos) ?\n)
+               (j-font-lock-docstring-p state))
+              ;; J Lab command
+              (eql (char-after start-pos) ?N))
+          font-lock-doc-face
+        font-lock-string-face))
      ((and (<= (+ start-pos 3) (point-max))
            (eql (char-after start-pos) ?N)
            (string= (buffer-substring-no-properties

--- a/j-help.el
+++ b/j-help.el
@@ -5,7 +5,7 @@
 ;; Copyright (C) 2023, 2024 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/ldbeth/j-mode
+;; URL: http://github.com/zellio/j-mode
 ;; Version: 2.0.1
 ;; Keywords: J, Languages
 

--- a/j-help.el
+++ b/j-help.el
@@ -48,7 +48,7 @@
   (if list
       (let* ((head (car list))
              (tail (cdr list)))
-        (if (eq (funcall fn head) (funcall fn prev))
+        (if (eql (funcall fn head) (funcall fn prev))
             (group-by* tail fn head (cons head coll) agr)
           (group-by* tail fn head '() (cons coll agr))))
     (cons coll agr)))

--- a/j-help.el
+++ b/j-help.el
@@ -6,7 +6,7 @@
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/ldbeth/j-mode
-;; Version: 2.0.0
+;; Version: 2.0.1
 ;; Keywords: J, Languages
 
 ;; This file is not part of GNU Emacs.
@@ -121,7 +121,7 @@ It groups the objects in LIST according to the predicate FN"
 (defconst j-help-dictionary-data-block
   (mapcar
    (lambda (l) (list (length (caar l))
-                     (regexp-opt (mapcar 'car l))
+                     (regexp-opt (mapcar #'car l))
                      l))
    (delq nil (group-by j-help-voc-alist (lambda (x) (length (car x))))))
   "(int * string * (string * string) alist) list")

--- a/j-help.el
+++ b/j-help.el
@@ -2,7 +2,7 @@
 ;;; j-help.el --- Documentation extention for j-mode
 
 ;; Copyright (C) 2012 Zachary Elliott
-;; Copyright (C) 2023 LdBeth
+;; Copyright (C) 2023, 2024 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
 ;; URL: http://github.com/ldbeth/j-mode
@@ -43,28 +43,21 @@
 
 ;;; Code:
 
-(defun group-by* ( list fn prev coll agr )
-  "Helper method for the group-by function. Should not be called directly."
-  (if list
-      (let* ((head (car list))
-             (tail (cdr list)))
-        (if (eql (funcall fn head) (funcall fn prev))
-            (group-by* tail fn head (cons head coll) agr)
-          (group-by* tail fn head '() (cons coll agr))))
-    (cons coll agr)))
-
-(defun group-by ( list fn )
-  "Group-by is a FUNCTION across LIST, returning a sequence
-It groups the objects in LIST according to the predicate FN"
-  (let ((sl (sort list (lambda (x y) (< (funcall fn x) (funcall fn y))))))
-    (group-by* sl fn '() '() '())))
-
-(defun j-some ( fn list )
-  (let (val)
-    (while (and list (not val))
-      (setq val (funcall fn (car list))
-            list (cdr list)))
-    val))
+(defun j-help--process-voc-list (alist)
+  (let ((table (make-hash-table))
+        res)
+    (dolist (x alist)
+      (let ((len (length (car x))))
+        (puthash len
+                 (cons x (gethash len table))
+                 table)))
+    (maphash (lambda (key l) (push
+                          (list key
+                               (regexp-opt (mapcar #'car l))
+                               l)
+                          res))
+             table)
+    res))
 
 (defgroup j-help nil
   "Documentation extention for j-mode"
@@ -119,11 +112,7 @@ It groups the objects in LIST according to the predicate FN"
   "(string * string) alist")
 
 (defconst j-help-dictionary-data-block
-  (mapcar
-   (lambda (l) (list (length (caar l))
-                     (regexp-opt (mapcar #'car l))
-                     l))
-   (delq nil (group-by j-help-voc-alist (lambda (x) (length (car x))))))
+  (j-help--process-voc-list j-help-voc-alist)
   "(int * string * (string * string) alist) list")
 
 (defun j-help-valid-dictionary ()
@@ -136,7 +125,6 @@ It groups the objects in LIST according to the predicate FN"
           j-help-remote-dictionary-url))))
 
 (defun j-help-symbol-pair-to-doc-url ( alist-data )
-  ""
   (let ((dic (j-help-valid-dictionary)))
     (if (or (not alist-data) (string= dic ""))
         (error "%s" "No dictionary found. Please specify a dictionary.")
@@ -148,21 +136,23 @@ It groups the objects in LIST according to the predicate FN"
   "Convert J-SYMBOL into localtion URL"
   (j-help-symbol-pair-to-doc-url (assoc j-symbol j-help-voc-alist)))
 
-(defun j-help-determine-symbol ( s point )
+(defun j-help--determine-symbol ( s point )
   "Internal function to determine j symbols. Should not be called directly
-
 string * int -> (string * string) list"
   (unless (or (< point 0) (< (length s) point))
-    (j-some
-     (lambda (x)
-       (let* ((check-size (car x)))
-         (if (and
-              (<= (+ check-size point) (length s))
-              (string-match (cadr x) (substring s point (+ point check-size))))
-           (let* ((m (match-data))
-                  (ss (substring s (+ point (car m)) (+ point (cadr m)))))
-             (assoc ss (caddr x))))))
-     j-help-dictionary-data-block)))
+    (let ((list j-help-dictionary-data-block)
+          val)
+      (while (and list (not val))
+        (setq val (let* ((x (car list))
+                         (check-size (car x)))
+                    (and
+                     (<= (+ check-size point) (length s))
+                     (string-match (cadr x) (substring s point (+ point check-size)))
+                     (let* ((m (match-data))
+                            (ss (substring s (+ point (car m)) (+ point (cadr m)))))
+                       (assoc ss (caddr x)))))
+              list (cdr list)))
+      val)))
 
 (defun j-help-determine-symbol-at-point ( point )
   "int -> (string * string) list"
@@ -171,13 +161,12 @@ string * int -> (string * string) list"
     (let* ((bol (pos-bol))
            (eol (pos-eol))
            (s (buffer-substring-no-properties bol eol)))
-      (j-help-determine-symbol s (- point bol)))))
+      (j-help--determine-symbol s (- point bol)))))
 
 (defun j-help-branch-determine-symbol-at-point*
   ( string current-index target-index resolved-symbol )
-  ""
   (if (> current-index target-index) resolved-symbol
-    (let ((next-symbol (j-help-determine-symbol string current-index)))
+    (let ((next-symbol (j-help--determine-symbol string current-index)))
       (j-help-branch-determine-symbol-at-point*
        string
        (+ current-index (length (or (car next-symbol) " ")))
@@ -185,7 +174,6 @@ string * int -> (string * string) list"
        next-symbol))))
 
 (defun j-help-branch-determine-symbol-at-point ( point )
-  ""
   (save-excursion
     (goto-char point)
     (j-help-branch-determine-symbol-at-point*

--- a/j-help.el
+++ b/j-help.el
@@ -1,10 +1,12 @@
-;;; j-help.el --- Documentation extention for j-mode -*- lexical-binding: t; -*-
+;; -*- lexical-binding:t -*-
+;;; j-help.el --- Documentation extention for j-mode
 
 ;; Copyright (C) 2012 Zachary Elliott
+;; Copyright (C) 2023 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/zellio/j-mode
-;; Version: 1.1.1
+;; URL: http://github.com/ldbeth/j-mode
+;; Version: 2.0.0
 ;; Keywords: J, Languages
 
 ;; This file is not part of GNU Emacs.
@@ -41,19 +43,6 @@
 
 ;;; Code:
 
-(defmacro if-let ( binding then &optional else )
-  "Bind value according to BINDING and check for truthy-ness
-If the test passes then eval THEN with the BINDING varlist bound
-If no, eval ELSE with no binding"
-  (let* ((sym (caar binding))
-         (tst (cdar binding))
-         (gts (gensym)))
-    `(let ((,gts ,@tst))
-       (if ,gts
-         (let ((,sym ,gts))
-           ,then)
-         ,else))))
-
 (defun group-by* ( list fn prev coll agr )
   "Helper method for the group-by function. Should not be called directly."
   (if list
@@ -70,15 +59,12 @@ It groups the objects in LIST according to the predicate FN"
   (let ((sl (sort list (lambda (x y) (< (funcall fn x) (funcall fn y))))))
     (group-by* sl fn '() '() '())))
 
-(unless (fboundp 'some)
-  (defun some ( fn list )
-    (when list
-      (let ((val (funcall fn (car list))))
-	(if val val (some fn (cdr list)))))))
-
-(unless (fboundp 'caddr)
-  (defun caddr ( list )
-    (car (cdr (cdr list)))))
+(defun j-some ( fn list )
+  (let (val)
+    (while (and list (not val))
+      (setq val (funcall fn (car list))
+            list (cdr list)))
+    val))
 
 (defgroup j-help nil
   "Documentation extention for j-mode"
@@ -154,7 +140,7 @@ It groups the objects in LIST according to the predicate FN"
   (let ((dic (j-help-valid-dictionary)))
     (if (or (not alist-data) (string= dic ""))
         (error "%s" "No dictionary found. Please specify a dictionary.")
-      (let ((name (car alist-data))
+      (let ((_name (car alist-data))
             (doc-name (cdr alist-data)))
         (format "%s/%s.%s" dic doc-name "htm")))))
 
@@ -167,7 +153,7 @@ It groups the objects in LIST according to the predicate FN"
 
 string * int -> (string * string) list"
   (unless (or (< point 0) (< (length s) point))
-    (some
+    (j-some
      (lambda (x)
        (let* ((check-size (car x)))
          (if (and
@@ -182,8 +168,8 @@ string * int -> (string * string) list"
   "int -> (string * string) list"
   (save-excursion
     (goto-char point)
-    (let* ((bol (point-at-bol))
-           (eol (point-at-eol))
+    (let* ((bol (pos-bol))
+           (eol (pos-eol))
            (s (buffer-substring-no-properties bol eol)))
       (j-help-determine-symbol s (- point bol)))))
 
@@ -203,9 +189,9 @@ string * int -> (string * string) list"
   (save-excursion
     (goto-char point)
     (j-help-branch-determine-symbol-at-point*
-     (buffer-substring-no-properties (point-at-bol) (point-at-eol))
-     (- (max (- point j-help-symbol-search-branch-limit) (point-at-bol)) (point-at-bol))
-     (- point (point-at-bol))
+     (buffer-substring-no-properties (pos-bol) (pos-eol))
+     (- (max (- point j-help-symbol-search-branch-limit) (pos-bol)) (pos-bol))
+     (- point (pos-bol))
      nil)))
 
 ;;;###autoload

--- a/j-mode.el
+++ b/j-mode.el
@@ -128,7 +128,7 @@ contents of current line."
     (save-excursion
       ;; skip empty/comment lines, if that leaves us in the first line, return 0
       (while (and (= (forward-line -1) 0)
-                  (if (looking-at "\\s *\\\\?$")
+                  (if (looking-at "^[ \t]*\\(?:NB\\..*\\)?$")
                       t
                     (setq indent (save-match-data
                                    (back-to-indentation)
@@ -168,9 +168,7 @@ contents of current line."
   kind of explicit definition we are `looking-at'. Modifies `match-data'!"
   ;; XXX we could dump the check for NB. if we prepending '^' to the others
   (cond ((j-thing-outside-string (rx (or (seq bow "define")
-                                         (seq ":" (* "\s") "0"))
-                                     (* "\s")
-                                     eol))
+                                         (seq ":" (* "\s") "0"))))
          :multi-liner)
         ((j-thing-outside-string (rx (or (seq bow "def")
                                          " :")

--- a/j-mode.el
+++ b/j-mode.el
@@ -241,7 +241,7 @@ contents of current line."
 
 ;;;###autoload
 (define-derived-mode j-mode prog-mode "J"
-  "Major mode for editing J"
+  "Major mode for editing J."
   :group 'j
   :syntax-table j-font-lock-syntax-table
   (setq-local comment-start
@@ -266,9 +266,16 @@ contents of current line."
                 (font-lock-syntactic-face-function
                  . j-font-lock-syntactic-face-function))))
 
+;;;###autoload
+(define-derived-mode j-lab-mode j-mode "J Lab"
+  "Mojor mode for J Labs."
+  :group 'j
+  (setq-local syntax-propertize-function #'j-lab-mode-syntax-propertize))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.ij[rstp]$" . j-mode))
+(progn
+  (add-to-list 'auto-mode-alist '("\\.ij[rsp]$" . j-mode))
+  (add-to-list 'auto-mode-alist '("\\.ijt$" . j-lab-mode)))
 
 (provide 'j-mode)
 

--- a/j-mode.el
+++ b/j-mode.el
@@ -5,7 +5,7 @@
 ;; Copyright (C) 2023, 2024 LdBeth
 ;;
 ;; Authors: Zachary Elliott <ZacharyElliott1@gmail.com>
-;; URL: http://github.com/ldbeth/j-mode
+;; URL: http://github.com/zellio/j-mode
 ;; Version: 2.0.1
 ;; Keywords: J, Langauges
 

--- a/j-mode.el
+++ b/j-mode.el
@@ -80,10 +80,11 @@
                        "try." "except." "catch." "catcht." "catchd."
                        "while." "whilst."
                        "for.")))
-                   (seq (or "for" "goto" "label")
-                        (regexp "_[a-zA-Z]+\\."))))
+                   (seq (or "for" "label") "_"
+                        (+ (any "a-zA-Z"))
+                        ".")))
           (seq bol ":" eol)
-          (seq (regexp "[_a-zA-Z0-9]+") (? "'")
+          (seq (+ (any "_a-zA-Z0-9")) (? "'")
                (* "\s") "=" (or "." ":") (* "\s")
                (or "{{"
                    (seq (regexp
@@ -102,7 +103,8 @@
                                      "else." "elseif."
                                      "case." "fcase."
                                      "catch." "catcht." "catchd."
-                                     "except.")))))))
+                                     "except."
+                                     "label")))))))
 
 (defun j-thing-outside-string (thing-regexp)
   "Look for REGEXP from `point' til `point-at-eol' outside strings and

--- a/j-mode.el
+++ b/j-mode.el
@@ -195,7 +195,7 @@ contents of current line."
       (:one-liner (beginning-of-line 2) t)
       (:multi-liner (search-forward-regexp "^)") t)
       (:direct (search-forward-regexp
-                (rx "}}" (or eol (not (any ".:")))))
+                (rx bol "}}" (? (not (any ".:")) (* nonl)) eol))
                t))))
 
 (defun j-beginning-of-explicit-definition ()

--- a/j-mode.el
+++ b/j-mode.el
@@ -52,6 +52,7 @@
 (require 'j-font-lock)
 (require 'j-console)
 (require 'j-help)
+(eval-when-compile (require 'rx))
 
 
 (defconst j-mode-version "1.1.1"
@@ -73,23 +74,28 @@
   :group 'j)
 
 (defconst j-indenting-keywords-regexp
-  (concat "\\<"
-          (regexp-opt '(;;"do\\."
-                        "if." "else." "elseif."
-                        "select." "case." "fcase."
-                        "throw."
-                        "try." "except." "catch." "catcht."
-                        "while." "whilst."
-                        "for." "for_"
-                        "label_"))
-          "\\|\\([_a-zA-Z0-9]+\\)\s*\\(=[.:]\\)\s*{{"))
+  (rx (or (seq bow
+               (or (regexp
+                    (regexp-opt
+                     '(;;"do\\."
+                       "if." "else." "elseif."
+                       "select." "case." "fcase."
+                       "throw."
+                       "try." "except." "catch." "catcht."
+                       "while." "whilst."
+                       "for.")))
+                   (seq (or "for" "goto" "label")
+                        (regexp "_[a-zA-Z]+\\."))))
+          (seq (regexp "[_a-zA-Z0-9]+")
+               (* "\s") "=" (or "." ":") (* "\s")
+               "{{"))))
 (defconst j-dedenting-keywords-regexp
-  (concat "}}\\|\\(\\<"
-          (regexp-opt '("end."
-                        "else." "elseif."
-                        "case." "fcase."
-                        "catch." "catcht." "except."))
-          "\\)"))
+  (rx (or "}}"
+          (seq bow
+               (regexp (regexp-opt '("end."
+                                     "else." "elseif."
+                                     "case." "fcase."
+                                     "catch." "catcht." "except.")))))))
 
 (defun j-thing-outside-string (thing-regexp)
   "Look for REGEXP from `point' til `point-at-eol' outside strings and


### PR DESCRIPTION
* Up-to-date with J9.5, added multiline string, direct function, corrected syntax table and added missing operators, etc.
* Refactored Emacs Lisp to use lexical binding.
* Code indenting support, referenced from Alexander Schmolck's j-mode but in the end I rolled my own.
* JLab format support
* Refactored comint and j-help

Known issues:
Multiline string cannot be empty. this is a sacrifice to correctly support the case when `0 : 0` is mixed with other code.
```
0 : 0, 'foo'
asdsd
)
```

The indentation is not perfect, and is fragile when nesting direct functions, but should be good for most cases.